### PR TITLE
FIX Bootstrap style for clear all button, and add paginator for LogViewerAdmin

### DIFF
--- a/src/Admin/LogViewerAdmin.php
+++ b/src/Admin/LogViewerAdmin.php
@@ -6,6 +6,7 @@ use SilverLeague\LogViewer\Model\LogEntry;
 use SilverLeague\LogViewer\Forms\GridField\GridFieldClearAllButton;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\View\Requirements;
 
 /**
@@ -65,6 +66,7 @@ class LogViewerAdmin extends ModelAdmin
         $config = $gridField->getConfig();
         $config->removeComponentsByType($config->getComponentByType(GridFieldAddNewButton::class));
         $config->addComponent(new GridFieldClearAllButton('buttons-before-left'));
+        $config->addComponent(new GridFieldPaginator);
 
         return $form;
     }

--- a/src/Forms/GridField/GridFieldClearAllButton.php
+++ b/src/Forms/GridField/GridFieldClearAllButton.php
@@ -41,10 +41,12 @@ class GridFieldClearAllButton implements GridField_HTMLProvider, GridField_Actio
     {
         $button = GridField_FormAction::create($gridField, 'clear', 'Clear all', 'clear', null);
         $button->setAttribute('data-icon', 'clear-all-logs');
-        $button->addExtraClass('font-icon-trash-bin action_clear action action-delete');
+        $button->addExtraClass('font-icon-trash-bin action_clear action action-delete btn btn-secondary');
         $button->setForm($gridField->getForm());
 
-        return [$this->targetFragment => '<p class="grid-clear-all-button">' . $button->Field() . '</p>'];
+        return [
+            $this->targetFragment => '<p class="grid-clear-all-button grid-print-button">' . $button->Field() . '</p>'
+        ];
     }
 
     /**

--- a/tests/Admin/LogViewerAdminTest.php
+++ b/tests/Admin/LogViewerAdminTest.php
@@ -6,6 +6,7 @@ use SilverLeague\LogViewer\Admin\LogViewerAdmin;
 use SilverLeague\LogViewer\Forms\GridField\GridFieldClearAllButton;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\ReadonlyField;
 
 /**
@@ -63,6 +64,17 @@ class LogViewerAdminTest extends FunctionalTest
         $this->assertInstanceOf(
             GridFieldClearAllButton::class,
             $this->getConfig()->getComponentByType(GridFieldClearAllButton::class)
+        );
+    }
+
+    /**
+     * Test that the GridField has a Paginator component
+     */
+    public function testHasPagination()
+    {
+        $this->assertInstanceOf(
+            GridFieldPaginator::class,
+            $this->getConfig()->getComponentByType(GridFieldPaginator::class)
         );
     }
 

--- a/tests/Forms/GridField/GridFieldClearAllButtonTest.php
+++ b/tests/Forms/GridField/GridFieldClearAllButtonTest.php
@@ -26,6 +26,9 @@ class GridFieldClearAllButtonTest extends SapphireTest
      */
     protected $usesDatabase = true;
 
+    /**
+     * @var GridField
+     */
     protected $gridField;
 
     /**
@@ -66,7 +69,7 @@ class GridFieldClearAllButtonTest extends SapphireTest
         $this->assertContains('Clear all', $fragments['before']);
         $this->assertContains('clear-all-logs', $fragments['before']);
         $this->assertContains('font-icon-trash-bin action_clear', $fragments['before']);
-        $this->assertContains('<p class="grid-clear-all-button">', $fragments['before']);
+        $this->assertContains('<p class="grid-clear-all-button grid-print-button">', $fragments['before']);
     }
 
     /**


### PR DESCRIPTION
The ModelAdmin should have pagination, since otherwise it just limits the page to the first 30 logs.

NOTE: There appears to be a framework bug in the pagination, which won't leave the first page of results.

cc @zanderwar