### PR TITLE
FIX Remove second paginator. The original is invisible, but will be fixed in the framework.

### DIFF
--- a/src/Admin/LogViewerAdmin.php
+++ b/src/Admin/LogViewerAdmin.php
@@ -6,7 +6,6 @@ use SilverLeague\LogViewer\Model\LogEntry;
 use SilverLeague\LogViewer\Forms\GridField\GridFieldClearAllButton;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
-use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\View\Requirements;
 
 /**
@@ -66,7 +65,6 @@ class LogViewerAdmin extends ModelAdmin
         $config = $gridField->getConfig();
         $config->removeComponentsByType($config->getComponentByType(GridFieldAddNewButton::class));
         $config->addComponent(new GridFieldClearAllButton('buttons-before-left'));
-        $config->addComponent(new GridFieldPaginator);
 
         return $form;
     }


### PR DESCRIPTION
There is already a Paginator in the default ModelAdmin GridField configuration, it is just not visible on the screen at the moment. This will be fixed in silverstripe/silverstripe-framework#6545, but we don't need a second one added since it breaks the page sizes, etc.