### PR TITLE
FIX Move tests to non-dev PSR-4 autoloader definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SilverLeague\\LogViewer\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "SilverLeague\\LogViewer\\": "src/",
             "SilverLeague\\LogViewer\\Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
`autoload-dev` is for root projects only, so would prevent test classes from being autoloaded when they're in modules.